### PR TITLE
use ELECTRUMD_EXE with priority if specified

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,6 @@ pub enum Error {
     NoFeature,
     /// Returned when calling methods requiring a env var to exist, but it's not
     NoEnvVar,
-    /// Returned when calling methods requiring either a feature or env var, but both are absent
-    NeitherFeatureNorEnvVar,
-    /// Returned when calling methods requiring either a feature or anv var, but both are present
-    BothFeatureAndEnvVar,
     /// Returned when expecting an auto-downloaded executable but `BITCOIND_SKIP_DOWNLOAD` env var is set
     SkipDownload,
 }
@@ -81,8 +77,6 @@ impl fmt::Debug for Error {
             Error::Json(e) => write!(f, "{:?}", e),
             Error::NoFeature => write!(f, "Called a method requiring a feature to be set, but it's not"),
             Error::NoEnvVar => write!(f, "Called a method requiring env var `ELECTRUMD_EXE` to be set, but it's not"),
-            Error::NeitherFeatureNorEnvVar =>  write!(f, "Called a method requiring env var `ELECTRUMD_EXE` or a feature to be set, but neither are set"),
-            Error::BothFeatureAndEnvVar => write!(f, "Called a method requiring env var `ELECTRUMD_EXE` or a feature to be set, but both are set"),
             Error::SkipDownload => write!(f, "expecting an auto-downloaded executable but `ELECTRUMD_SKIP_DOWNLOAD` env var is set"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,16 +316,13 @@ pub fn downloaded_exe_path() -> Result<String, Error> {
     }
 }
 
-/// Returns the daemon executable path if it's provided as a feature or as `ELECTRUMD_EXE` env var.
-/// Returns error if none or both are set
+/// Returns the daemon executable path as specified via `ELECTRUMD_EXE` env var.
+/// Otherwise try to use the downloaded path
 pub fn exe_path() -> Result<String, Error> {
-    match (downloaded_exe_path(), std::env::var("ELECTRUMD_EXE")) {
-        (Ok(_), Ok(_)) => Err(Error::BothFeatureAndEnvVar),
-        (Ok(path), Err(_)) => Ok(path),
-        (Err(_), Ok(path)) => Ok(path),
-        (Err(Error::NoFeature), Err(_)) => Err(Error::NeitherFeatureNorEnvVar),
-        (Err(Error::SkipDownload), Err(_)) => Err(Error::SkipDownload),
-        (Err(_), Err(_)) => unreachable!(),
+    if let Ok(path) = std::env::var("ELECTRUMD_EXE") {
+        Ok(path)
+    } else {
+        downloaded_exe_path()
     }
 }
 


### PR DESCRIPTION
On nixos auto-download features fails because provided executable don't work on that platform.
Having the `ELECTRUMD_EXE` env var having priority would allow those system to work.
This is similar to what has been done on bitcoind crate https://github.com/rust-bitcoin/bitcoind/pull/122 for the same reason